### PR TITLE
AppBuilder: always return a Map in get_kv_meta_for, albeit empty

### DIFF
--- a/hase/macro/AppBuilder.hx
+++ b/hase/macro/AppBuilder.hx
@@ -47,14 +47,14 @@ class AppBuilder
     private inline function strip_colon(val:String):String
         return val.charAt(0) == ":" ? val.substr(1) : val;
 
-    private function get_kv_meta_for(key:String):Null<Map<String, Expr>>
+    private function get_kv_meta_for(key:String):Map<String, Expr>
     {
         var params:Null<Array<Expr>> = this.meta.get(key);
+        var result:Map<String, Expr> = new Map();
 
         if (params == null)
-            return null;
+            return result;
 
-        var result:Map<String, Expr> = new Map();
         for (p in params) {
             switch (p) {
                 case macro $i{key} = $val:


### PR DESCRIPTION
The rest of AppBuilder (specifically create_statistics) assumes
get_kv_meta_for returns a Map always. Since it is then checked if the
desired key is _really_ in the Map, it is perfectly fine to return an
empty Map.

This fixes the build of example which would previously crash because the AppBuilder would try to call `null.exists("use_canvas")`.